### PR TITLE
Missing parameter in recursive process_conf call

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -176,7 +176,7 @@ def process_conf(resource_obj, command, conf_name, run = false)
   case resource_obj
   when Array
     resource_obj.each_with_index do |obj, i|
-      process_conf(obj, command, "#{conf_name}_#{i + 1}")
+      process_conf(obj, command, "#{conf_name}_#{i + 1}", run)
     end
   when Hash
     write_conf(conf_path, resource_obj)


### PR DESCRIPTION
When process_conf is recursively calling itself when an Array is passed as the resource_obj will never run the exec_flyway command. Inside the 'each_with_index' loop, the run parameter is not passed resulting in a defaulted 'run' of false.

Corrected to pass the run value passed to process_conf
